### PR TITLE
feat: support training text encoder in SDXL script

### DIFF
--- a/sdxl_unet_train_infer_runtime_text.py
+++ b/sdxl_unet_train_infer_runtime_text.py
@@ -16,6 +16,7 @@ import numpy as np
 from PIL import Image
 from pathlib import Path
 from collections import deque, OrderedDict
+import contextlib
 
 import torch
 import torch.nn.functional as F
@@ -189,11 +190,12 @@ class SDXLTextEnc:
       - pooled_prompt_embeds: TE2 的 pooled/text_embeds -> [B,1280]
     支持 LRU 缓存（按文本串）
     """
-    def __init__(self, base_repo: str, device, use_amp=True, cache_cap: int = 0):
+    def __init__(self, base_repo: str, device, use_amp=True, cache_cap: int = 0, train_te: bool = False):
         self.device = device
         self.use_amp = use_amp
         self.cache_cap = int(cache_cap)
         self.cache: "OrderedDict[str, Tuple[torch.Tensor, torch.Tensor]]" = OrderedDict()
+        self.train_te = bool(train_te)
 
         self.tokenizer_1 = CLIPTokenizer.from_pretrained(base_repo, subfolder="tokenizer")
         self.tokenizer_2 = CLIPTokenizer.from_pretrained(base_repo, subfolder="tokenizer_2")
@@ -201,11 +203,18 @@ class SDXLTextEnc:
         dtype = torch.float16 if device.type=="cuda" else torch.float32
         self.text_encoder_1 = CLIPTextModel.from_pretrained(base_repo, subfolder="text_encoder", torch_dtype=dtype).to(device)
         self.text_encoder_2 = CLIPTextModelWithProjection.from_pretrained(base_repo, subfolder="text_encoder_2", torch_dtype=dtype).to(device)
-        self.text_encoder_1.eval().requires_grad_(False)
-        self.text_encoder_2.eval().requires_grad_(False)
+        if self.train_te:
+            self.text_encoder_1.train().requires_grad_(True)
+            self.text_encoder_2.train().requires_grad_(True)
+        else:
+            self.text_encoder_1.eval().requires_grad_(False)
+            self.text_encoder_2.eval().requires_grad_(False)
 
         # 预计算无条件
-        self.uncond_prompt_embeds, self.uncond_pooled = self.encode_prompts([""])
+        if not self.train_te:
+            self.uncond_prompt_embeds, self.uncond_pooled = self.encode_prompts([""])
+        else:
+            self.uncond_prompt_embeds, self.uncond_pooled = None, None
 
     def _encode_no_cache(self, texts: List[str]) -> Tuple[torch.Tensor, torch.Tensor]:
         ids1 = self.tokenizer_1(texts, padding="max_length", max_length=77,
@@ -220,13 +229,14 @@ class SDXLTextEnc:
         prompt_embeds = torch.cat([z1, z2_hidden], dim=-1)          # [B,77,2048]
         return prompt_embeds, z2_pooled
 
-    @torch.no_grad()
     def encode_prompts(self, texts: List[str]) -> Tuple[torch.Tensor, torch.Tensor]:
-        return self._encode_no_cache(texts)
+        if self.train_te:
+            return self._encode_no_cache(texts)
+        with torch.no_grad():
+            return self._encode_no_cache(texts)
 
-    @torch.no_grad()
     def encode_cached(self, text: str) -> Tuple[torch.Tensor, torch.Tensor]:
-        if self.cache_cap <= 0:
+        if self.train_te or self.cache_cap <= 0:
             return self._encode_no_cache([text])
         if text in self.cache:
             pe_cpu, pooled_cpu = self.cache.pop(text)
@@ -257,7 +267,7 @@ def build_time_ids(width: int, height: int, crop_w=0, crop_h=0, target_w=None, t
 # -------------------------
 # 断点保存/恢复
 # -------------------------
-def save_train_state(path, unet, optimizer, lr_sched, ema, global_step, epoch,
+def save_train_state(path, unet, txt, optimizer, lr_sched, ema, global_step, epoch,
                      prediction_type, scaler=None, opt_step=0):
     pkg = {
         "model": {k: v.detach().cpu() for k, v in unet.state_dict().items()},
@@ -271,6 +281,9 @@ def save_train_state(path, unet, optimizer, lr_sched, ema, global_step, epoch,
         "opt_step": int(opt_step),
         "scaler": (scaler.state_dict() if (scaler is not None and hasattr(scaler, "state_dict")) else None),
     }
+    if getattr(txt, "train_te", False):
+        pkg["text_encoder_1"] = {k: v.detach().cpu() for k, v in txt.text_encoder_1.state_dict().items()}
+        pkg["text_encoder_2"] = {k: v.detach().cpu() for k, v in txt.text_encoder_2.state_dict().items()}
     os.makedirs(os.path.dirname(path), exist_ok=True)
     tmp_fd, tmp_path = tempfile.mkstemp(suffix=".pt", dir=os.path.dirname(path))
     os.close(tmp_fd)
@@ -348,7 +361,7 @@ def try_load_train_state(resume_path, unet, optimizer, lr_sched, ema, scaler=Non
 # -------------------------
 # 保存推理用权重（EMA）+ 旁车 json
 # -------------------------
-def save_ckpt(args, unet, ema, step: int, prediction_type: str, lr_sched_step: int):
+def save_ckpt(args, unet, ema, txt, step: int, prediction_type: str, lr_sched_step: int):
     # ⛏️ 自动清理旧的 checkpoint（只保留最近10个）
     ckpt_dirs = sorted(glob.glob(os.path.join(args.out_dir, "step_*_ema")), key=os.path.getmtime)
     max_keep = 1
@@ -394,8 +407,15 @@ def save_ckpt(args, unet, ema, step: int, prediction_type: str, lr_sched_step: i
     safetensors_save({k: v.detach().cpu() for k,v in ema_model.state_dict().items()}, os.path.join(ema_dir, "unet_ema.safetensors"))
     with open(os.path.join(ema_dir, "config.json"), "w", encoding="utf-8") as f:
         json.dump(unet.config, f, indent=2)
+    meta = {"prediction_type": prediction_type, "step": step}
+    if getattr(args, "train_text_encoder", False):
+        safetensors_save({k: v.detach().cpu() for k, v in txt.text_encoder_1.state_dict().items()},
+                         os.path.join(ema_dir, "text_encoder_1.safetensors"))
+        safetensors_save({k: v.detach().cpu() for k, v in txt.text_encoder_2.state_dict().items()},
+                         os.path.join(ema_dir, "text_encoder_2.safetensors"))
+        meta["text_encoder_saved"] = True
     with open(os.path.join(ema_dir, "meta.json"), "w", encoding="utf-8") as f:
-        json.dump({"prediction_type": prediction_type, "step": step}, f, indent=2)
+        json.dump(meta, f, indent=2)
     # 旁车 state.json（便于从 safetensors 恢复）
     with open(os.path.join(ema_dir, "unet_ema.state.json"), "w", encoding="utf-8") as f:
         json.dump({
@@ -622,6 +642,9 @@ def cmd_train(args):
     use_amp = (device.type == "cuda")
     os.makedirs(args.out_dir, exist_ok=True)
 
+    if args.train_text_encoder and not (args.text_encoder_lr < args.lr):
+        raise ValueError("--text_encoder_lr must be smaller than --lr")
+
     # 数据
     index_path = os.path.join(args.data_dir, "index.jsonl")
     dataset = LatentCapAuthorDataset(index_path, args.data_dir)
@@ -645,10 +668,20 @@ def cmd_train(args):
                                 prediction_type=prediction_type)
 
     # 文本编码器（带 LRU 缓存）
-    txt = SDXLTextEnc(base_repo, device, use_amp=True, cache_cap=args.embed_cache_size)
+    txt = SDXLTextEnc(
+        base_repo,
+        device,
+        use_amp=True,
+        cache_cap=(0 if args.train_text_encoder else args.embed_cache_size),
+        train_te=args.train_text_encoder,
+    )
 
     # 优化器/EMA/AMP
-    optimizer = torch.optim.AdamW(unet.parameters(), lr=args.lr, betas=(0.9,0.999), weight_decay=1e-2)
+    param_groups = [{"params": unet.parameters(), "lr": args.lr}]
+    if args.train_text_encoder:
+        te_params = list(txt.text_encoder_1.parameters()) + list(txt.text_encoder_2.parameters())
+        param_groups.append({"params": te_params, "lr": args.text_encoder_lr})
+    optimizer = torch.optim.AdamW(param_groups, betas=(0.9,0.999), weight_decay=1e-2)
     ema = EMA(unet, decay=args.ema)
     scaler = torch.amp.GradScaler('cuda', enabled=use_amp)
 
@@ -742,14 +775,14 @@ def cmd_train(args):
         negative = getattr(args, "preview_negative", None)
         do_cfg = float(args.preview_scale) > 1.0
 
-        pe, neg_pe, pooled, neg_pooled = pipe.encode_prompt(
-            prompt=[prompt],
-            negative_prompt=[negative] if (do_cfg and negative) else None,
-            device=device,
-            num_images_per_prompt=1,
-            do_classifier_free_guidance=do_cfg,
-            # 注意：这里不要传 dtype=...
-        )
+        pe, pooled = txt.encode_prompts([prompt])
+        if do_cfg:
+            if negative:
+                neg_pe, neg_pooled = txt.encode_prompts([negative])
+            else:
+                neg_pe, neg_pooled = txt.encode_prompts([""])
+        else:
+            neg_pe = neg_pooled = None
 
         # 统一 dtype/device
         pe       = pe.to(device=device, dtype=tmp_dtype)
@@ -757,8 +790,6 @@ def cmd_train(args):
         if do_cfg and neg_pe is not None and neg_pooled is not None:
             neg_pe    = neg_pe.to(device=device, dtype=tmp_dtype)
             neg_pooled= neg_pooled.to(device=device, dtype=tmp_dtype)
-        else:
-            neg_pe = neg_pooled = None
 
         # 3) add_time_ids（与尺寸一致；按 batch 扩展）
         try:
@@ -900,9 +931,9 @@ def cmd_train(args):
             pe_list, pooled_list = [], []
             for s in chosen:
                 if (args.cfg_drop > 0.0) and (random.random() < args.cfg_drop):
-                    pe, pooled = txt.uncond_prompt_embeds, txt.uncond_pooled
+                    pe, pooled = txt.encode_cached("")
                 else:
-                    pe, pooled = txt.encode_cached(s) if s else (txt.uncond_prompt_embeds, txt.uncond_pooled)
+                    pe, pooled = txt.encode_cached(s)
                 pe_list.append(pe)
                 pooled_list.append(pooled)
 
@@ -979,7 +1010,7 @@ def cmd_train(args):
             scaler.scale(loss / args.grad_accum).backward()
 
             if ((global_step + 1) % args.grad_accum) == 0:
-                nn.utils.clip_grad_norm_(unet.parameters(), 1.0)
+                nn.utils.clip_grad_norm_(train_params, 1.0)
                 scaler.step(optimizer)
                 scaler.update()
                 optimizer.zero_grad(set_to_none=True)
@@ -996,13 +1027,13 @@ def cmd_train(args):
                 os.makedirs(snap_dir, exist_ok=True)
                 # 仅保存推理用 ckpt（你之前注释掉了 state 保存）
                 save_ckpt(
-                    args, unet, ema,
+                    args, unet, ema, txt,
                     step=global_step,
                     prediction_type=prediction_type,
                     lr_sched_step=lr_sched.step_idx
                 )
                 # save_train_state(os.path.join(snap_dir, "state.pt"),
-                #                  unet, optimizer, lr_sched, ema,
+                #                  unet, txt, optimizer, lr_sched, ema,
                 #                  global_step=global_step, epoch=epoch,
                 #                  prediction_type=prediction_type,
                 #                  scaler=scaler, opt_step=opt_step)
@@ -1021,7 +1052,7 @@ def cmd_train(args):
 
         if args.save_epochs and ((epoch + 1) % args.save_epochs == 0):
             save_ckpt(
-                args, unet, ema,
+                args, unet, ema, txt,
                 step=global_step,
                 prediction_type=prediction_type,
                 lr_sched_step=lr_sched.step_idx
@@ -1154,6 +1185,8 @@ def build_parser():
     pt.add_argument("--workers", type=int, default=4)
     pt.add_argument("--epochs", type=int, default=1)
     pt.add_argument("--lr", type=float, default=1e-4)
+    pt.add_argument("--text_encoder_lr", type=float, default=1e-5,
+                    help="text encoder learning rate (must be < --lr)")
     pt.add_argument("--warmup", type=int, default=1000)
     pt.add_argument("--grad_accum", type=int, default=1)
     pt.add_argument("--ema", type=float, default=0.999)
@@ -1177,6 +1210,7 @@ def build_parser():
     pt.add_argument("--plot_interval", type=int, default=500, help="每隔多少 step 刷新一次 loss.csv/loss.png")
     pt.add_argument("--loss_ema", type=float, default=0.98, help="loss EMA 平滑系数，1.0 表示关闭平滑")
     pt.add_argument("--embed_cache_size", type=int, default=50000, help="文本嵌入 LRU 缓存上限（按不同文本条目数）")
+    pt.add_argument("--train_text_encoder", action="store_true", help="同时训练 Text Encoder")
 
     pt.set_defaults(func=cmd_train)
 


### PR DESCRIPTION
## Summary
- allow optionally training SDXL text encoders
- add `--text_encoder_lr` flag to use a smaller rate for text encoders
- integrate text encoder parameters into training loop and previews
- save text encoder weights alongside UNet checkpoints

## Testing
- `python -m py_compile sdxl_unet_train_infer_runtime_text.py`
- `python sdxl_unet_train_infer_runtime_text.py train --help | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c37bfe8c508324875c80123f56a517